### PR TITLE
bump sentencepiece to 0.1.99

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ typeguard==2.13.3
 einops
 hydra-core
 opt-einsum
-sentencepiece==0.1.97
+sentencepiece==0.1.99
 ctc-segmentation>=1.6.6
 humanfriendly
 torch_complex


### PR DESCRIPTION
Sentencepiece 0.1.98+ provides binary wheel support for Python 3.11. This eases the installation of speechcatcher.